### PR TITLE
GH-22: Fix zwave_command_class_node_info_resolver unit test

### DIFF
--- a/applications/zpc/components/zwave_command_classes/test/zwave_command_class_node_info_resolver_test.c
+++ b/applications/zpc/components/zwave_command_classes/test/zwave_command_class_node_info_resolver_test.c
@@ -73,9 +73,9 @@ void attribute_resolver_set_resolution_give_up_listener_stub(
   attribute_resolver_callback_t callback,
   int cmock_num_calls)
 {
-  TEST_ASSERT_EQUAL(ATTRIBUTE_ZWAVE_NIF, node_type);
-  on_nif_resolution_abort = callback;
-  return;
+  if (ATTRIBUTE_ZWAVE_NIF == node_type) {
+    on_nif_resolution_abort = callback;
+  }
 }
 
 sl_status_t zwave_controller_register_callbacks_stub(


### PR DESCRIPTION
GH-22 add a new callback on the give_up_listener on the ATTRIBUTE_ZWAVE_SECURE_NIF attribute causing the test case to fail.

The test only expect this listener to be called on the non-secure NIF ATTRIBUTE_ZWAVE_NIF. This change make sure that the code is only executed in the context of ATTRIBUTE_ZWAVE_NIF and ignored  for ATTRIBUTE_ZWAVE_SECURE_NIF as this test don't care about it.

Bug-SiliconLabs: UIC-3082
Relate-to: https://github.com/SiliconLabs/UnifySDK/pull/22
Forwarded-SiliconLabs: task/UIC-3082/phcoval/GH-22/develop

## Change
<!--
  Describe your changes below.

  (internal references are encouraged in commit messages as well,
  please align to others changes)

-->

## Checklist
<!--
  Please put an `x` in each box to make sure to enable contribution process
-->

- [x] A [Contribution License Agreement][CLA] has been established between @SiliconLabs and author's company (matching email domain)

[CLA]: https://en.wikipedia.org/wiki/Contributor_License_Agreement


